### PR TITLE
Let the service die when the device to read kbd codes sieze to exist

### DIFF
--- a/teres1-ledctrl.c
+++ b/teres1-ledctrl.c
@@ -15,6 +15,9 @@
 #include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <errno.h>
+#include <string.h>
+#include <unistd.h>
 
 #include <linux/input.h>
 
@@ -95,7 +98,13 @@ int main (int argc, char **argv)
         break;
       }
       break;
+    default:
+      if(errno == ENODEV){ // gpio device is gone
+	exit(1);
+      }
     }
+    errno = 0;
+
   }
 
   return 0;


### PR DESCRIPTION
In case when TERES1 laptop is put to sleep and resumes, the service gets back online trying to read from a device, which does not exist anymore.

So the service does not work, but also is not stopped since all errors are ignore and as a "bonus" it actually takes 100% of the CPU core.

As a solution added exit condition in the main loop, when error ENODEV is received on read from the device. Also some headers were added to avoid warnings.

 In general if one kills the system the device is already recreated and systemd restarts the service and everything is OK after that. So to be honest I also considered a solution to add systemd script to kill the service on resume, but figured out this might be less portable solution.